### PR TITLE
Bump Node.js version to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, ba
 ## Documentation and resources
 
 * Upstream app code repository: <https://github.com/jellyfin/jellyfin-vue>
+* YunoHost Store: <https://apps.yunohost.org/app/jellyfin-vue>
 * Report a bug: <https://github.com/YunoHost-Apps/jellyfin-vue_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -28,6 +28,7 @@ Jellyfin Vue est la prochaine étape du développement de Jellyfin. C'est une no
 ## Documentations et ressources
 
 * Dépôt de code officiel de l’app : <https://github.com/jellyfin/jellyfin-vue>
+* YunoHost Store: <https://apps.yunohost.org/app/jellyfin-vue>
 * Signaler un bug : <https://github.com/YunoHost-Apps/jellyfin-vue_ynh/issues>
 
 ## Informations pour les développeurs

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-nodejs_version=18
+nodejs_version=20
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -27,7 +27,7 @@ _npm_build_install() {
     pushd "$sourcedir" || ynh_die "Could not pushd $sourcedir"
         ynh_use_nodejs
         ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" \
-            "$ynh_npm" install
+            "$ynh_npm" ci --no-audit --ignore-scripts
         ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" \
             "$ynh_npm" run build -- --base="$subpath/"
     popd || ynh_die "Could not popd"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -24,12 +24,12 @@ _npm_build_install() {
     targetdir=$2
     subpath=$3
 
-    pushd "$sourcedir" || ynh_die "Could not pushd $sourcedir"
-        ynh_use_nodejs
+    ynh_use_nodejs
+    pushd "$sourcedir/frontend" || ynh_die "Could not pushd $sourcedir/frontend"
         ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" \
             "$ynh_npm" ci --no-audit --ignore-scripts
         ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" \
-            "$ynh_npm" run build -- --base="$subpath/"
+            "$ynh_npm" run build
     popd || ynh_die "Could not popd"
 
     mv "$sourcedir/frontend/dist" "$targetdir"


### PR DESCRIPTION
## Problem

- Jellyfin-vue fails to build

## Solution

- Use node 20 as upstream seems to have switched.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
