### PR TITLE
Upgrade to v2025.01.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Shipped version:** 2025.01.13~ynh1
+**Shipped version:** 2025.01.26~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versión actual:** 2025.01.13~ynh1
+**Versión actual:** 2025.01.26~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Paketatutako bertsioa:** 2025.01.13~ynh1
+**Paketatutako bertsioa:** 2025.01.26~ynh1
 
 **Demoa:** <https://jf-vue.pages.dev>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Jellyfin Vue est la prochaine étape du développement de Jellyfin. C'est une nouvelle interface, basée sur Vue. Des détails peuvent être trouvés ici : https://jellyfin.org/posts/vue-vue3.
 
 
-**Version incluse :** 2025.01.13~ynh1
+**Version incluse :** 2025.01.26~ynh1
 
 **Démo :** <https://jf-vue.pages.dev>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versión proporcionada:** 2025.01.13~ynh1
+**Versión proporcionada:** 2025.01.26~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versi terkirim:** 2025.01.13~ynh1
+**Versi terkirim:** 2025.01.26~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Geleverde versie:** 2025.01.13~ynh1
+**Geleverde versie:** 2025.01.26~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Dostarczona wersja:** 2025.01.13~ynh1
+**Dostarczona wersja:** 2025.01.26~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Поставляемая версия:** 2025.01.13~ynh1
+**Поставляемая версия:** 2025.01.26~ynh1
 
 **Демо-версия:** <https://jf-vue.pages.dev>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**分发版本：** 2025.01.13~ynh1
+**分发版本：** 2025.01.26~ynh1
 
 **演示：** <https://jf-vue.pages.dev>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin Vue Client"
 description.en = "Modern web client for Jellyfin"
 description.fr = "Client web moderne pour Jellyfin"
 
-version = "2025.01.13~ynh1"
+version = "2025.01.26~ynh1"
 
 maintainers = []
 
@@ -45,8 +45,8 @@ ram.runtime = "0M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/jellyfin/jellyfin-vue/archive/d9a491c03969680a38276bac26791e053cdda30d.tar.gz"
-    sha256 = "5ae2ba803612330264a5b6141b6aab4a8dcf4a19672b16272c189093c2d66901"
+    url = "https://github.com/jellyfin/jellyfin-vue/archive/f55d98737d266156e55c0a7d356ecfb091c99aa9.tar.gz"
+    sha256 = "5a34066a4ee074b0fe39b95eb0f42f7ba88b629bdd3e3fef3d5688994d0c8456"
 
     autoupdate.upstream = "https://github.com/jellyfin/jellyfin-vue/"
     autoupdate.strategy = "latest_github_commit"


### PR DESCRIPTION
Upgrade sources
- `main` v2025.01.26: https://github.com/jellyfin/jellyfin-vue/compare/d9a491c03969680a38276bac26791e053cdda30d...f55d98737d266156e55c0a7d356ecfb091c99aa9