### PR TITLE
Upgrade to v2025.02.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Shipped version:** 2025.02.10~ynh1
+**Shipped version:** 2025.02.18~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versión actual:** 2025.02.10~ynh1
+**Versión actual:** 2025.02.18~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Paketatutako bertsioa:** 2025.02.10~ynh1
+**Paketatutako bertsioa:** 2025.02.18~ynh1
 
 **Demoa:** <https://jf-vue.pages.dev>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Jellyfin Vue est la prochaine étape du développement de Jellyfin. C'est une nouvelle interface, basée sur Vue. Des détails peuvent être trouvés ici : https://jellyfin.org/posts/vue-vue3.
 
 
-**Version incluse :** 2025.02.10~ynh1
+**Version incluse :** 2025.02.18~ynh1
 
 **Démo :** <https://jf-vue.pages.dev>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versión proporcionada:** 2025.02.10~ynh1
+**Versión proporcionada:** 2025.02.18~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versi terkirim:** 2025.02.10~ynh1
+**Versi terkirim:** 2025.02.18~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Geleverde versie:** 2025.02.10~ynh1
+**Geleverde versie:** 2025.02.18~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Dostarczona wersja:** 2025.02.10~ynh1
+**Dostarczona wersja:** 2025.02.18~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Поставляемая версия:** 2025.02.10~ynh1
+**Поставляемая версия:** 2025.02.18~ynh1
 
 **Демо-версия:** <https://jf-vue.pages.dev>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**分发版本：** 2025.02.10~ynh1
+**分发版本：** 2025.02.18~ynh1
 
 **演示：** <https://jf-vue.pages.dev>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin Vue Client"
 description.en = "Modern web client for Jellyfin"
 description.fr = "Client web moderne pour Jellyfin"
 
-version = "2025.02.10~ynh1"
+version = "2025.02.18~ynh1"
 
 maintainers = []
 
@@ -48,8 +48,8 @@ ram.runtime = "0M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/jellyfin/jellyfin-vue/archive/878ef6f3f0bd0d2a20e5bd4081b618b794bebd6e.tar.gz"
-    sha256 = "7d5c85c360e1fd51ad46c0c2b6d12d29c87f302961917acdc357b05bf53afae7"
+    url = "https://github.com/jellyfin/jellyfin-vue/archive/9a51881a5aedf608ba9e6505b67c69b1297dec4e.tar.gz"
+    sha256 = "998fe2297ef090e4e08847247a38a5a77c3eaf3ba6e8118cc70ce6359a63335c"
 
     autoupdate.upstream = "https://github.com/jellyfin/jellyfin-vue/"
     autoupdate.strategy = "latest_github_commit"


### PR DESCRIPTION
Upgrade sources
- `main` v2025.02.18: https://github.com/jellyfin/jellyfin-vue/compare/878ef6f3f0bd0d2a20e5bd4081b618b794bebd6e...9a51881a5aedf608ba9e6505b67c69b1297dec4e

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
