### PR TITLE
Upgrade to v2025.03.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Shipped version:** 2025.03.15~ynh1
+**Shipped version:** 2025.03.22~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versión actual:** 2025.03.15~ynh1
+**Versión actual:** 2025.03.22~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Paketatutako bertsioa:** 2025.03.15~ynh1
+**Paketatutako bertsioa:** 2025.03.22~ynh1
 
 **Demoa:** <https://jf-vue.pages.dev>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Jellyfin Vue est la prochaine étape du développement de Jellyfin. C'est une nouvelle interface, basée sur Vue. Des détails peuvent être trouvés ici : https://jellyfin.org/posts/vue-vue3.
 
 
-**Version incluse :** 2025.03.15~ynh1
+**Version incluse :** 2025.03.22~ynh1
 
 **Démo :** <https://jf-vue.pages.dev>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versión proporcionada:** 2025.03.15~ynh1
+**Versión proporcionada:** 2025.03.22~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Versi terkirim:** 2025.03.15~ynh1
+**Versi terkirim:** 2025.03.22~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Geleverde versie:** 2025.03.15~ynh1
+**Geleverde versie:** 2025.03.22~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Dostarczona wersja:** 2025.03.15~ynh1
+**Dostarczona wersja:** 2025.03.22~ynh1
 
 **Demo:** <https://jf-vue.pages.dev>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**Поставляемая версия:** 2025.03.15~ynh1
+**Поставляемая версия:** 2025.03.22~ynh1
 
 **Демо-версия:** <https://jf-vue.pages.dev>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Jellyfin Vue is the next step of Jellyfin's development. It's a new frontend, based on Vue. See https://jellyfin.org/posts/vue-vue3 for details.
 
 
-**分发版本：** 2025.03.15~ynh1
+**分发版本：** 2025.03.22~ynh1
 
 **演示：** <https://jf-vue.pages.dev>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin Vue Client"
 description.en = "Modern web client for Jellyfin"
 description.fr = "Client web moderne pour Jellyfin"
 
-version = "2025.03.15~ynh1"
+version = "2025.03.22~ynh1"
 
 maintainers = []
 
@@ -48,8 +48,8 @@ ram.runtime = "0M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/jellyfin/jellyfin-vue/archive/69716c043982b29e0af36a909eacbe8772ff9540.tar.gz"
-    sha256 = "115b4191b9eb4e6493bcc17b096dbd2435a6bd7a37d9e355bb156aaf537dbaa5"
+    url = "https://github.com/jellyfin/jellyfin-vue/archive/d5bca1ae54bf0718ca382dc6e37c9a099f8f9050.tar.gz"
+    sha256 = "c9f65a93194233cabd91e476639a32addcd93233720f400c10a526733c9fac2f"
 
     autoupdate.upstream = "https://github.com/jellyfin/jellyfin-vue/"
     autoupdate.strategy = "latest_github_commit"


### PR DESCRIPTION
Upgrade sources
- `main` v2025.03.22: https://github.com/jellyfin/jellyfin-vue/compare/69716c043982b29e0af36a909eacbe8772ff9540...d5bca1ae54bf0718ca382dc6e37c9a099f8f9050

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
